### PR TITLE
Add observer of matrix

### DIFF
--- a/addon/components/zoom-zone.js
+++ b/addon/components/zoom-zone.js
@@ -4,6 +4,7 @@ const {
   Component,
   run,
   computed,
+  observer,
   $
 } = Ember;
 
@@ -65,6 +66,11 @@ export default Component.extend({
   matrix: computed('panX', 'panY', 'scale', function () {
     const [scale, x, y] = [this.get('scale'), this.get('panX'), this.get('panY')];
     return `matrix(${scale}, 0, 0, ${scale}, ${x}, ${y})`;
+  }),
+
+  matrixCss: observer('matrix', '$content', function () {
+    const content = this.get('$content');
+    content.css({transform: this.get('matrix')});
   }),
 
   zoomFit() {

--- a/addon/components/zoom-zone.js
+++ b/addon/components/zoom-zone.js
@@ -68,7 +68,7 @@ export default Component.extend({
     return `matrix(${scale}, 0, 0, ${scale}, ${x}, ${y})`;
   }),
 
-  matrixCss: observer('matrix', '$content', function () {
+  matrixCss: observer('matrix', function () {
     const content = this.get('$content');
     content.css({transform: this.get('matrix')});
   }),


### PR DESCRIPTION
Adds observer to css matrix so that if some one changes a pan or scale of the dependent data it is reflected in the css. This also preserves ddau.